### PR TITLE
fix: File management not working on Windows 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1247,7 +1247,10 @@ async function closePreview() {
 
 async function onDidSaveTextDocument(document: vscode.TextDocument) {
   // Check if the saved document is our oil file
-  if (tempFilePath && document.uri.fsPath === vscode.Uri.file(tempFilePath).fsPath) {
+  if (
+    tempFilePath &&
+    document.uri.fsPath === vscode.Uri.file(tempFilePath).fsPath
+  ) {
     try {
       // Process changes - now we need to handle both current changes
       // and any pending changes from navigation

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,11 @@ let pendingChanges: PendingChanges = {
   renamedFiles: new Map(),
 };
 
+// Helper function for cross-platform path handling
+function normalizePath(inputPath: string): string {
+  return inputPath.split(/[\/\\]/).join(path.sep);
+}
+
 // Function to exclude oil files from recent files by adding to exclude patterns
 async function configureRecentFilesExclusions() {
   try {
@@ -669,8 +674,12 @@ async function handleOilFileSave(
         fs.mkdirSync(dirPath, { recursive: true });
       }
 
+      // Make sure both paths use correct separators for the platform
+      const normalizedOldPath = normalizePath(oldPath);
+      const normalizedNewPath = normalizePath(newPath);
+
       // Move the file to the new location
-      fs.renameSync(oldPath, newPath);
+      fs.renameSync(normalizedOldPath, normalizedNewPath);
     } catch (error) {
       vscode.window.showErrorMessage(
         `Failed to move file: ${path.basename(oldPath)} to ${newPath.replace(
@@ -683,8 +692,8 @@ async function handleOilFileSave(
 
   // Process the confirmed changes for renames in the same directory
   for (const [oldName, newName] of renamedPairs) {
-    const oldPath = path.join(currentPath, oldName);
-    const newPath = path.join(currentPath, newName);
+    const oldPath = normalizePath(path.join(currentPath, oldName));
+    const newPath = normalizePath(path.join(currentPath, newName));
 
     // Check if this is a rename including directories
     if (

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,11 +40,6 @@ let pendingChanges: PendingChanges = {
   renamedFiles: new Map(),
 };
 
-// Helper function for cross-platform path handling
-function normalizePath(inputPath: string): string {
-  return inputPath.split(/[\/\\]/).join(path.sep);
-}
-
 // Function to exclude oil files from recent files by adding to exclude patterns
 async function configureRecentFilesExclusions() {
   try {
@@ -674,12 +669,8 @@ async function handleOilFileSave(
         fs.mkdirSync(dirPath, { recursive: true });
       }
 
-      // Make sure both paths use correct separators for the platform
-      const normalizedOldPath = normalizePath(oldPath);
-      const normalizedNewPath = normalizePath(newPath);
-
       // Move the file to the new location
-      fs.renameSync(normalizedOldPath, normalizedNewPath);
+      fs.renameSync(oldPath, newPath);
     } catch (error) {
       vscode.window.showErrorMessage(
         `Failed to move file: ${path.basename(oldPath)} to ${newPath.replace(
@@ -692,8 +683,8 @@ async function handleOilFileSave(
 
   // Process the confirmed changes for renames in the same directory
   for (const [oldName, newName] of renamedPairs) {
-    const oldPath = normalizePath(path.join(currentPath, oldName));
-    const newPath = normalizePath(path.join(currentPath, newName));
+    const oldPath = path.join(currentPath, oldName);
+    const newPath = path.join(currentPath, newName);
 
     // Check if this is a rename including directories
     if (
@@ -1256,7 +1247,7 @@ async function closePreview() {
 
 async function onDidSaveTextDocument(document: vscode.TextDocument) {
   // Check if the saved document is our oil file
-  if (tempFilePath && document.uri.fsPath === tempFilePath) {
+  if (tempFilePath && document.uri.fsPath === vscode.Uri.file(tempFilePath).fsPath) {
     try {
       // Process changes - now we need to handle both current changes
       // and any pending changes from navigation


### PR DESCRIPTION
# fix: File management not working on Windows

This PR addresses an issue where the changes in the oil.code file would be ignored due to an unexpected difference when comparing the path of the active document and the stored temp file path. This is a documented choice by VSCode https://github.com/Microsoft/vscode/blob/c110d84460b3e45842a8fe753562341003595e1d/src/vs/vscode.d.ts#L1304 and won't be changing based on previous issues opened against this difference.

fixes #5 