### PR TITLE
fix: Better keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,64 @@ To open oil.code:
 | `-`                        | `alt+-`          | `oil-code.openParent` | Navigate to parent directory                    |
 | `ctrl+p`                   | `alt+p`          | `oil-code.preview`    | Toggle preview window of entry under the cursor |
 
+### [vscode-neovim](https://github.com/vscode-neovim/vscode-neovim) Keymaps
+
+If you're using vscode-neovim and want to customize the keymaps for oil.code:
+
+1. Set `oil-code.disableDefaultKeymaps` to `true` in your VSCode settings
+2. Add the following to your `init.lua` and customize as you like:
+
+```lua
+-- Default oil.code keymaps
+if vim.g.vscode then
+    local vscode = require('vscode-neovim')
+    local map = vim.keymap.set
+
+    vim.api.nvim_create_autocmd({'BufEnter', 'BufWinEnter'}, {
+        pattern = {"*"},
+        callback = function()
+            map("n", "-", function() vscode.action('oil-code.open') end)
+        end,
+    })
+
+    vim.api.nvim_create_autocmd({'BufEnter', 'BufWinEnter'}, {
+        pattern = {"*oil.code*"},
+        callback = function()
+            map("n", "-", function() vscode.action('oil-code.openParent') end)
+            map("n", "<CR>", function() vscode.action('oil-code.select') end)
+        end,
+    })
+end
+```
+
+### [VSCodeVim](https://github.com/VSCodeVim/Vim) Keymaps
+
+If you're using VSCodeVim and want to customize the keymaps for oil.code:
+
+1. Set `oil-code.disableDefaultKeymaps` to `true` in your VSCode settings
+2. Add the following to your `settings.json` and customize as you like:
+
+```json
+"vim.normalModeKeyBindings": [
+    {
+        "before": ["-"],
+        "commands": [
+            {
+                "command": "oil-code.open"
+            }
+        ]
+    },
+    {
+        "before": ["<CR>"],
+        "commands": [
+            {
+                "command": "oil-code.select"
+            }
+        ]
+    }
+]
+```
+
 ## Why oil.code?
 
 Oil.nvim is a favorite plugin of mine and I find myself going back and forth between Neovim and VSCode for various projects. Being able to quickly rename or move a file is an experience I want everywhere and I want to share with the great community of VSCode and Codium users.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This plugin works best with [VSCodeVim](https://github.com/VSCodeVim/Vim) or [vs
 To open oil.code:
 
 - Vim users - With a file focused and in normal mode press `-`.
-- All users - Press `alt+o`.
+- All users - Press `alt+-`.
 
 | Vim Shortcut (normal mode) | Default Shortcut | Command               | Description                                     |
 | -------------------------- | ---------------- | --------------------- | ----------------------------------------------- |

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -44,27 +46,12 @@
     "keybindings": [
       {
         "command": "oil-code.open",
-        "key": "-",
-        "when": "editorTextFocus && editorLangId != oil && (vim.mode == 'Normal' || neovim.mode == normal)"
-      },
-      {
-        "command": "oil-code.open",
         "key": "alt+o"
-      },
-      {
-        "command": "oil-code.select",
-        "key": "enter",
-        "when": "editorTextFocus && editorLangId == oil && (vim.mode == 'Normal' || neovim.mode == normal)"
       },
       {
         "command": "oil-code.select",
         "key": "alt+enter",
         "when": "editorTextFocus && editorLangId == oil"
-      },
-      {
-        "command": "oil-code.openParent",
-        "key": "-",
-        "when": "editorLangId == oil && (vim.mode == 'Normal' || neovim.mode == normal)"
       },
       {
         "command": "oil-code.openParent",

--- a/package.json
+++ b/package.json
@@ -46,11 +46,6 @@
     "keybindings": [
       {
         "command": "oil-code.open",
-        "key": "-",
-        "when": "editorTextFocus && (vim.mode == 'Normal')"
-      },
-      {
-        "command": "oil-code.open",
         "key": "alt+-"
       },
       {

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     ],
     "keybindings": [
       {
+        "command": "oil-code.open",
         "key": "-",
-        "when": "editorTextFocus && editorLangId != oil && (vim.mode == 'Normal')",
-        "command": "oil-code.open"
+        "when": "editorTextFocus && editorLangId != oil && (vim.mode == 'Normal')"
       },
       {
         "command": "oil-code.open",
@@ -55,13 +55,18 @@
       },
       {
         "command": "oil-code.select",
+        "key": "enter",
+        "when": "editorTextFocus && editorLangId == oil && (vim.mode == 'Normal')"
+      },
+      {
+        "command": "oil-code.select",
         "key": "alt+enter",
         "when": "editorTextFocus && editorLangId == oil"
       },
       {
-        "key": "enter",
-        "when": "editorTextFocus && editorLangId == oil && (vim.mode == 'Normal')",
-        "command": "oil-code.select"
+        "command": "oil-code.openParent",
+        "key": "-",
+        "when": "editorTextFocus && editorLangId == oil && (vim.mode == 'Normal')"
       },
       {
         "command": "oil-code.openParent",

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
       {
         "command": "oil-code.open",
         "key": "-",
-        "when": "editorTextFocus && editorLangId != oil && (vim.mode == 'Normal')"
+        "when": "editorTextFocus && (vim.mode == 'Normal')"
       },
       {
         "command": "oil-code.open",
-        "key": "alt+o"
+        "key": "alt+-"
       },
       {
         "command": "oil-code.select",
@@ -61,16 +61,6 @@
       {
         "command": "oil-code.select",
         "key": "alt+enter",
-        "when": "editorTextFocus && editorLangId == oil"
-      },
-      {
-        "command": "oil-code.openParent",
-        "key": "-",
-        "when": "editorTextFocus && editorLangId == oil && (vim.mode == 'Normal')"
-      },
-      {
-        "command": "oil-code.openParent",
-        "key": "alt+-",
         "when": "editorTextFocus && editorLangId == oil"
       },
       {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
     ],
     "keybindings": [
       {
+        "key": "-",
+        "when": "editorTextFocus && editorLangId != oil && (vim.mode == 'Normal')",
+        "command": "oil-code.open"
+      },
+      {
         "command": "oil-code.open",
         "key": "alt+o"
       },
@@ -52,6 +57,11 @@
         "command": "oil-code.select",
         "key": "alt+enter",
         "when": "editorTextFocus && editorLangId == oil"
+      },
+      {
+        "key": "enter",
+        "when": "editorTextFocus && editorLangId == oil && (vim.mode == 'Normal')",
+        "command": "oil-code.select"
       },
       {
         "command": "oil-code.openParent",
@@ -75,7 +85,17 @@
         "scopeName": "source.oil",
         "path": "./syntaxes/oil.tmLanguage.json"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "oil.code",
+      "properties": {
+        "oil-code.neovimOpenOilKeymap": {
+          "type": "string",
+          "default": "-",
+          "description": "Key to bind to oil-code.open in Neovim mode. Default is '-'."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "pnpm run package",

--- a/package.json
+++ b/package.json
@@ -50,11 +50,6 @@
       },
       {
         "command": "oil-code.select",
-        "key": "enter",
-        "when": "editorTextFocus && editorLangId == oil && (vim.mode == 'Normal')"
-      },
-      {
-        "command": "oil-code.select",
         "key": "alt+enter",
         "when": "editorTextFocus && editorLangId == oil"
       },
@@ -79,10 +74,10 @@
     "configuration": {
       "title": "oil.code",
       "properties": {
-        "oil-code.neovimOpenOilKeymap": {
-          "type": "string",
-          "default": "-",
-          "description": "Key to bind to oil-code.open in Neovim mode. Default is '-'."
+        "oil-code.disableVimKeymaps": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable all Vim keymaps for oil.code. Default is false. Set this to true if you want to set your own keymaps. Reload after changing this setting."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,6 +115,10 @@ async function openOil() {
   let folderPath: string | undefined;
 
   if (activeEditor) {
+    if (activeEditor.document.languageId === "oil") {
+      openParent();
+      return;
+    }
     const filePath = activeEditor.document.uri.fsPath;
     folderPath = vscode.Uri.file(filePath).with({
       path: require("path").dirname(filePath),
@@ -1325,18 +1329,21 @@ async function registerNeovimKeymap() {
       await vscode.commands.executeCommand(
         "vscode-neovim.lua",
         `
-vim.keymap.set("n", "${keymap}", function() require('vscode').action('oil-code.open') end)
+local vscode = require('vscode')
+local map = vim.keymap.set
+map("n", "${keymap}", function() vscode.action('oil-code.open') end)
 vim.api.nvim_create_autocmd({'BufEnter', 'BufWinEnter'}, {
     pattern = {"*"},
     callback = function()
-        vim.keymap.set("n", "${keymap}", function() require('vscode').action('oil-code.open') end)
+        map("n", "${keymap}", function() vscode.action('oil-code.open') end)
     end,
 })
+
 vim.api.nvim_create_autocmd({'BufEnter', 'BufWinEnter'}, {
     pattern = {"${tempFileName}"},
     callback = function()
-        vim.keymap.set("n", "-", function() require('vscode').action('oil-code.openParent') end)
-        vim.keymap.set("n", "<CR>", function() require('vscode').action('oil-code.select') end)
+        map("n", "-", function() vscode.action('oil-code.openParent') end)
+        map("n", "<CR>", function() vscode.action('oil-code.select') end)
     end,
 })
         `


### PR DESCRIPTION
# fix: Better keymaps

This PR enhances the Vim keymap options to use native vim/neovim plugin bindings. This also aims to resolve the issue where "f-" would open oil instead of going to the next "-" character.

fixes #3 