### PR TITLE
feat: Add cd command and keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To open oil.code:
 | `_`                        | `alt+shift+-`    | `oil-code.openCwd`        | Navigate to current working directory            |
 | `ctrl+p`                   | `alt+p`          | `oil-code.preview`        | Toggle preview window of entry under the cursor  |
 | `ctrl+l`                   | `alt+l`          | `oil-code.refresh`        | Refresh directory listing from disk              |
+| `\``                       | `alt+\``         | `oil-code.cd`             | Change Directory to current                      |
 
 ### [vscode-neovim](https://github.com/vscode-neovim/vscode-neovim) Keymaps
 
@@ -51,6 +52,7 @@ if vim.g.vscode then
             map("n", "<CR>", function() vscode.action('oil-code.select') end)
             map("n", "<C-t>", function() vscode.action('oil-code.selectTab') end)
             map("n", "<C-l>", function() vscode.action('oil-code.refresh') end)
+            map("n", "\`", function() vscode.action('oil-code.cd') end)
         end,
     })
 end
@@ -126,7 +128,7 @@ Key:
 | ["\<C-l\>"] = "actions.refresh"                                  | ✅       |
 | ["-"] = { "actions.parent", mode = "n" }                         | ✅       |
 | ["_"] = { "actions.open_cwd", mode = "n" }                       | ✅       |
-| ["`"] = { "actions.cd", mode = "n" }                             | ❓       |
+| ["`"] = { "actions.cd", mode = "n" }                             | ✅[^4]   |
 | ["~"] = { "actions.cd", opts = { scope = "tab" }, mode = "n" }   | ❓       |
 | ["gs"] = { "actions.change_sort", mode = "n" }                   | ❌       |
 | ["gx"] = "actions.open_external"                                 | ❓       |
@@ -136,6 +138,7 @@ Key:
 [^1]: If VSCode is opened and no files are opened, the oil window will open. This can be disabled in settings.
 [^2]: Keymap might have conflicts with VSCode keymaps or and may require additional config
 [^3]: `oil-code.close` is implemented but I was not able to set the default keymap of "\<C-c\>"
+[^4]: `oil-code.cd` is implemented but the workspace reloads and pending changes do not persist.
 
 ## Icons
 

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ To open oil.code:
 - Vim users - With a file focused and in normal mode press `-`.
 - All users - Press `alt+-`.
 
-| Vim Shortcut (normal mode) | Default Shortcut | Command                   | Description                                      |
-| -------------------------- | ---------------- | ------------------------- | ------------------------------------------------ |
-| `Enter`                    | `alt+Enter`      | `oil-code.select`         | Open file or enter directory                     |
-| `ctrl+t`                   | `alt+t`          | `oil-code.selectTab`      | Open file or enter directory in new tab          |
-| -- No Default --           | `alt+s`          | `oil-code.selectVertical` | Open file or enter directory in adjacent v-split |
-| -- No Default --           | `alt+c`          | `oil-code.close`          | Close active oil file and open previous file     |
-| `-`                        | `alt+-`          | `oil-code.openParent`     | Navigate to parent directory                     |
-| `_`                        | `alt+shift+-`    | `oil-code.openCwd`        | Navigate to current working directory            |
-| `ctrl+p`                   | `alt+p`          | `oil-code.preview`        | Toggle preview window of entry under the cursor  |
-| `ctrl+l`                   | `alt+l`          | `oil-code.refresh`        | Refresh directory listing from disk              |
-| `\``                       | `alt+\``         | `oil-code.cd`             | Change Directory to current                      |
+| Vim Shortcut (normal mode) | Default Shortcut    | Command                   | Description                                      |
+| -------------------------- | ------------------- | ------------------------- | ------------------------------------------------ |
+| `Enter`                    | `alt+Enter`         | `oil-code.select`         | Open file or enter directory                     |
+| `ctrl+t`                   | `alt+t`             | `oil-code.selectTab`      | Open file or enter directory in new tab          |
+| -- No Default --           | `alt+s`             | `oil-code.selectVertical` | Open file or enter directory in adjacent v-split |
+| -- No Default --           | `alt+c`             | `oil-code.close`          | Close active oil file and open previous file     |
+| `-`                        | `alt+-`             | `oil-code.openParent`     | Navigate to parent directory                     |
+| `_`                        | `alt+shift+-`       | `oil-code.openCwd`        | Navigate to current working directory            |
+| `ctrl+p`                   | `alt+p`             | `oil-code.preview`        | Toggle preview window of entry under the cursor  |
+| `ctrl+l`                   | `alt+l`             | `oil-code.refresh`        | Refresh directory listing from disk              |
+| <code>\`</code>            | <code>alt+\`</code> | `oil-code.cd`             | Change Directory to current                      |
 
 ### [vscode-neovim](https://github.com/vscode-neovim/vscode-neovim) Keymaps
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
       {
         "command": "oil-code.refresh",
         "title": "Oil: Refresh - Refresh directory listing from disk"
+      },
+      {
+        "command": "oil-code.cd",
+        "title": "Oil: cd - Change directory to the currently opened directory",
+        "when": "editorTextFocus && editorLangId == oil"
       }
     ],
     "languages": [
@@ -108,6 +113,11 @@
       {
         "command": "oil-code.refresh",
         "key": "alt+l",
+        "when": "editorTextFocus && editorLangId == oil"
+      },
+      {
+        "command": "oil-code.cd",
+        "key": "alt+`",
         "when": "editorTextFocus && editorLangId == oil"
       }
     ],


### PR DESCRIPTION
# feat: Add cd command and keymaps

This PR add the cd (change directory) command.

This is useful if you have an open vscode window and want to use oil to navigate and select a new folder to open.