### PR TITLE
fix: Ignore empty lines when determining changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1093,6 +1093,9 @@ function oilLinesToOilEntries(
     if (entry.identifier === "/000") {
       continue;
     }
+    if (!entry.value) {
+      continue; // Skip empty lines
+    }
     map.push([entry.identifier, entry]);
   }
   return map;

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -217,6 +217,33 @@ suite("oil.code", () => {
     ]);
   });
 
+  test("Creates file and ignores empty lines", async () => {
+    await vscode.commands.executeCommand("oil-code.open");
+    await waitFor(() =>
+      assert.strictEqual(
+        vscode.window.activeTextEditor?.document.getText(),
+        "/000 ../"
+      )
+    );
+    const editor = vscode.window.activeTextEditor;
+    assert.ok(editor, "No active editor");
+
+    await editor.edit((editBuilder) => {
+      editBuilder.insert(
+        new vscode.Position(1, 0),
+        ["", "oil-file.md", ""].join(newline)
+      );
+    });
+
+    await saveFile();
+
+    // Wait for file content to update
+    await waitForDocumentText(["/000 ../", "/001 oil-file.md"]);
+
+    // Check if the file was created
+    await assertProjectFileStructure(["oil-file.md"]);
+  });
+
   test("Edit and renames file", async () => {
     await vscode.commands.executeCommand("oil-code.open");
     await waitForDocumentText("/000 ../");


### PR DESCRIPTION
<!--
Replace the title below with your PR title following conventional commits format:
Examples: "feat: add directory navigation with arrow keys", "fix: resolve file preview crash", "docs: update installation guide"
-->

# fix: Ignore empty lines when determining changes

## 📝 Description

<!--
Provide a clear and concise description of what this PR does:
- What problem does it solve?
- What functionality does it add?
- How does it improve the extension?
-->
This PR updates the logic determining file changes to ignore empty lines.

## 🔧 Type of Change

<!-- Mark the relevant option(s) with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (adding missing tests or correcting existing tests)
- [ ] 🎨 Style changes (formatting, missing semi-colons, etc)
- [ ] 🔧 Chore (maintenance tasks, dependency updates)
- [ ] 🌟 Other (please describe):

## 🔗 Related Issues

<!-- Link any related issues using "Fixes #123", "Closes #123", or "Resolves #123" -->
<!-- If no related issues, you can remove this section or write "N/A" -->

- Fixes #27 

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Additional Notes

<!-- Add any additional notes or context about the PR -->
