### PR TITLE
fix: Update cursor position after save

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1495,6 +1495,11 @@ async function onDidSaveTextDocument(document: vscode.TextDocument) {
         // Get file name from the current cursor position
         const currentLine = document.lineAt(cursorPosition.line).text;
         cursorOnFileName = currentLine.replace(/^\/\d{3} /, "").trim();
+        if (cursorOnFileName.includes("/")) {
+          // If the cursor is on a file with a path, just use the folder name
+          const parts = cursorOnFileName.split("/");
+          cursorOnFileName = parts.at(0) + "/";
+        }
       }
 
       await vscode.workspace.applyEdit(edit);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -7,6 +7,7 @@ import { newline } from "../newline";
 import { saveFile } from "./utils/saveFile";
 import { sleep } from "./utils/sleep";
 import { assertProjectFileStructure } from "./utils/assertProjectFileStructure";
+import { moveCursorToLine } from "./utils/moveCursorToLine";
 
 async function cleanupTestDir() {
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
@@ -106,6 +107,11 @@ suite("oil.code", () => {
     // Wait for file content to update
     await waitForDocumentText(["/000 ../", "/001 oil-file.ts"]);
     await assertProjectFileStructure(["oil-file.ts"]);
+    assert.strictEqual(
+      editor.selection.active.line,
+      0,
+      "Cursor position is not updated"
+    );
   });
 
   test("Creates directory", async () => {
@@ -123,12 +129,18 @@ suite("oil.code", () => {
       `/000 ../${newline}oil-dir/`,
       "Text was not typed into editor"
     );
+    moveCursorToLine(editor, 1);
 
     await saveFile();
 
     // Wait for file content to update
     await waitForDocumentText(["/000 ../", "/001 oil-dir/"]);
     await assertProjectFileStructure(["oil-dir/"]);
+    assert.strictEqual(
+      editor.selection.active.line,
+      1,
+      "Cursor position is not updated"
+    );
   });
 
   test("Creates directory and file in one line", async () => {
@@ -151,6 +163,8 @@ suite("oil.code", () => {
       "Text was not typed into editor"
     );
 
+    moveCursorToLine(editor, 1);
+
     await saveFile();
 
     // Wait for file content to update
@@ -158,6 +172,11 @@ suite("oil.code", () => {
 
     // Check if the file was created
     await assertProjectFileStructure(["oil-dir/", "  oil-file.ts"]);
+    assert.strictEqual(
+      editor.selection.active.line,
+      1,
+      "Cursor position is not updated"
+    );
   });
 
   test("Creates various files and directories in one step", async () => {
@@ -188,6 +207,8 @@ suite("oil.code", () => {
       );
     });
 
+    moveCursorToLine(editor, 8);
+
     await saveFile();
 
     // Wait for file content to update
@@ -200,6 +221,9 @@ suite("oil.code", () => {
       "/005 oil-file.js",
       "/006 oil-file.md",
     ]);
+
+    // Check cursor position is updated
+    assert.strictEqual(editor.selection.active.line, 3);
 
     // Check if the file was created
     await assertProjectFileStructure([
@@ -231,14 +255,17 @@ suite("oil.code", () => {
     await editor.edit((editBuilder) => {
       editBuilder.insert(
         new vscode.Position(1, 0),
-        ["", "oil-file.md", ""].join(newline)
+        ["", "", "oil-file.md"].join(newline)
       );
     });
+    moveCursorToLine(editor, 1);
 
     await saveFile();
 
     // Wait for file content to update
     await waitForDocumentText(["/000 ../", "/001 oil-file.md"]);
+    // Check cursor position is updated
+    assert.strictEqual(editor.selection.active.line, 1);
 
     // Check if the file was created
     await assertProjectFileStructure(["oil-file.md"]);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -222,9 +222,6 @@ suite("oil.code", () => {
       "/006 oil-file.md",
     ]);
 
-    // Check cursor position is updated
-    assert.strictEqual(editor.selection.active.line, 3);
-
     // Check if the file was created
     await assertProjectFileStructure([
       "index.html",
@@ -239,6 +236,9 @@ suite("oil.code", () => {
       "oil-file.js",
       "oil-file.md",
     ]);
+
+    // Check cursor position is updated
+    assert.strictEqual(editor.selection.active.line, 3);
   });
 
   test("Creates file and ignores empty lines", async () => {
@@ -264,6 +264,7 @@ suite("oil.code", () => {
 
     // Wait for file content to update
     await waitForDocumentText(["/000 ../", "/001 oil-file.md"]);
+
     // Check cursor position is updated
     assert.strictEqual(editor.selection.active.line, 1);
 

--- a/src/test/utils/moveCursorToLine.ts
+++ b/src/test/utils/moveCursorToLine.ts
@@ -1,0 +1,8 @@
+import * as vscode from "vscode";
+
+export function moveCursorToLine(editor: vscode.TextEditor, lineNumber = 1) {
+  editor.selection = new vscode.Selection(
+    new vscode.Position(lineNumber, 0),
+    new vscode.Position(lineNumber, 0)
+  );
+}


### PR DESCRIPTION
<!--
Replace the title below with your PR title following conventional commits format:
Examples: "feat: add directory navigation with arrow keys", "fix: resolve file preview crash", "docs: update installation guide"
-->

# fix: Update cursor position after save

## 📝 Description

<!--
Provide a clear and concise description of what this PR does:
- What problem does it solve?
- What functionality does it add?
- How does it improve the extension?
-->
This PR updates the cursor position when you save to be on the same file/line before the file operations are done and the directory contents are reloaded. This helps when you create a file and want to edit it, you will no longer have to then move to that line to enter the file.

## 🔧 Type of Change

<!-- Mark the relevant option(s) with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (adding missing tests or correcting existing tests)
- [ ] 🎨 Style changes (formatting, missing semi-colons, etc)
- [ ] 🔧 Chore (maintenance tasks, dependency updates)
- [ ] 🌟 Other (please describe):

## 🔗 Related Issues

<!-- Link any related issues using "Fixes #123", "Closes #123", or "Resolves #123" -->
<!-- If no related issues, you can remove this section or write "N/A" -->

-

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Additional Notes

<!-- Add any additional notes or context about the PR -->
