### PR TITLE
fix: update shell-quote transitive dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,8 @@
       "@azure/msal-node>uuid": "14.0.0",
       "brace-expansion@<1.1.13": "1.1.13",
       "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
-      "brace-expansion@>=5.0.0 <5.0.6": "5.0.6"
+      "brace-expansion@>=5.0.0 <5.0.6": "5.0.6",
+      "npm-run-all>shell-quote": "1.8.4"
     },
     "onlyBuiltDependencies": [
       "@vscode/vsce-sign",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   brace-expansion@<1.1.13: 1.1.13
   brace-expansion@>=2.0.0 <2.0.3: 2.0.3
   brace-expansion@>=5.0.0 <5.0.6: 5.0.6
+  npm-run-all>shell-quote: 1.8.4
 
 importers:
 
@@ -2938,8 +2939,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -6053,7 +6054,7 @@ snapshots:
       minimatch: 3.1.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       string.prototype.padend: 3.1.6
 
   npm-run-path@4.0.1:
@@ -6586,7 +6587,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Add a narrow pnpm override for `npm-run-all > shell-quote` so the transitive dependency resolves to patched `shell-quote@1.8.4`.
- Refresh `pnpm-lock.yaml` to remove vulnerable `shell-quote@1.8.3` from the dependency graph.

## Security context
- Addresses Dependabot alert for `shell-quote` command injection: `GHSA-w7jw-789q-3m8p` / `CVE-2026-9277`.
- Vulnerable path before: `. > npm-run-all > shell-quote@1.8.3`.
- Resolved path after: `. > npm-run-all > shell-quote@1.8.4`.

## Verification
- `pnpm audit --json` → 0 vulnerabilities
- `pnpm why shell-quote` → `npm-run-all 4.1.5 -> shell-quote 1.8.4`
- `pnpm run check-types`
- `pnpm run lint`
- `pnpm run package`
