### PR TITLE
docs: use static MIT license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align="center">Edit your filesystem like a normal file.</p>
 <p align=center>
 <a href="https://github.com/corwinm/oil.code/actions/workflows/main.yml"><img src="https://github.com/corwinm/oil.code/actions/workflows/main.yml/badge.svg"></a>
-<a href="https://github.com/corwinm/oil.code/blob/main/LICENSE"><img src="https://img.shields.io/github/license/corwinm/oil.code"></a>
+<a href="https://github.com/corwinm/oil.code/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 <a href="https://github.com/corwinm/oil.code/releases"><img src="https://img.shields.io/github/v/release/corwinm/oil.code?label=release"></a>
 
 </p>


### PR DESCRIPTION
## Summary
- Replaces the dynamic GitHub license Shields badge with a static MIT badge.
- Avoids stale/incorrect `license: invalid` rendering from the GitHub README image proxy cache.

## Verification
- Confirmed `https://img.shields.io/badge/license-MIT-blue.svg` returns `license: MIT`.
- README-only change; no build/test run needed.
