### PR TITLE
fix: align vscode typings with engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "~25.9.1",
     "@types/sinon": "^21.0.1",
-    "@types/vscode": "1.120.0",
+    "@types/vscode": "1.96.0",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.60.0",
     "@vscode/test-cli": "^0.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^21.0.1
         version: 21.0.1
       '@types/vscode':
-        specifier: 1.120.0
-        version: 1.120.0
+        specifier: 1.96.0
+        version: 1.96.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.60.0
         version: 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)
@@ -748,8 +748,8 @@ packages:
   '@types/sinonjs__fake-timers@15.0.1':
     resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
-  '@types/vscode@1.120.0':
-    resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
+  '@types/vscode@1.96.0':
+    resolution: {integrity: sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==}
 
   '@typescript-eslint/eslint-plugin@8.60.0':
     resolution: {integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==}
@@ -4165,7 +4165,7 @@ snapshots:
 
   '@types/sinonjs__fake-timers@15.0.1': {}
 
-  '@types/vscode@1.120.0': {}
+  '@types/vscode@1.96.0': {}
 
   '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)':
     dependencies:


### PR DESCRIPTION
## Summary
- Downgrades `@types/vscode` to `1.96.0` so the typings align with the declared `engines.vscode` range (`^1.96.2`).
- Updates `pnpm-lock.yaml` accordingly.
- Fixes the release packaging failure from `vsce package`: `@types/vscode 1.120.0 greater than engines.vscode ^1.96.2`.

## Test Plan
- `pnpm run check-types`
- `pnpm run lint`
- `pnpm test` — 26 passing
- `pnpm exec vsce package --no-dependencies --out /tmp/oil-code-test.vsix`

## Notes
- I tried `@types/vscode@1.96.2` first, but that exact package version does not exist on npm. `1.96.0` is the matching available typings release for the declared VS Code engine floor.