### PR TITLE
ci: publish VS Marketplace with Entra ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -38,6 +39,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Authenticate to Azure for VS Marketplace publishing
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"
@@ -52,6 +61,5 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
           OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
           NODE_ENV: production

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -62,7 +62,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "pnpm run verify:release && xvfb-run -a pnpm test && mkdir -p dist && pnpm exec vsce package --no-dependencies --out dist/oil-code-${nextRelease.version}.vsix",
-        "publishCmd": "if [ -z \"$VSCE_PAT\" ]; then echo 'VSCE_PAT is required to publish to VS Marketplace'; exit 1; fi && if [ -z \"$OPEN_VSX_TOKEN\" ]; then echo 'OPEN_VSX_TOKEN is required to publish to Open VSX'; exit 1; fi && pnpm exec vsce publish --packagePath dist/oil-code-${nextRelease.version}.vsix && pnpm exec ovsx publish dist/oil-code-${nextRelease.version}.vsix -p \"$OPEN_VSX_TOKEN\""
+        "publishCmd": "if [ -z \"$OPEN_VSX_TOKEN\" ]; then echo 'OPEN_VSX_TOKEN is required to publish to Open VSX'; exit 1; fi && pnpm exec vsce publish --azure-credential --packagePath dist/oil-code-${nextRelease.version}.vsix && pnpm exec ovsx publish dist/oil-code-${nextRelease.version}.vsix -p \"$OPEN_VSX_TOKEN\""
       }
     ],
     [

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Oil.nvim is a favorite plugin of mine and I find myself going back and forth bet
 
 Odds are good that if you found this plugin, you are like me and have experienced Oil.nvim and have found yourself back in VSCode and miss oil dearly.
 
+## Release publishing
+
+- VS Marketplace publishing uses Microsoft Entra ID via GitHub Actions OIDC and `vsce publish --azure-credential`.
+- Open VSX publishing still uses `OPEN_VSX_TOKEN`.
+- Required GitHub secrets for release publishing: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, and `OPEN_VSX_TOKEN`.
+- The Azure identity must be federated with the `Release` workflow and added to the VS Marketplace publisher with the Contributor role.
+
 ## oil.nvim feature comparison
 
 The goal of this project isn't to be an exact implementation of oil.nvim for VSCode but rather to provide the most used and useful parts of it. If you use something that hasn't been implemented, please open an issue and let me know what is missing and how you typically use it.

--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
   "scripts": {
     "vscode:prepublish": "pnpm run package",
     "compile": "pnpm run check-types && pnpm run lint && node esbuild.js",
-    "deploy": "vsce publish --no-dependencies",
+    "deploy": "vsce publish --no-dependencies --azure-credential",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",


### PR DESCRIPTION
## Summary
- switch VS Marketplace release publishing from `VSCE_PAT` to `vsce publish --azure-credential`
- add GitHub Actions OIDC permission and Azure login for the release workflow
- document required Azure/OIDC secrets and Marketplace publisher role setup

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run check-types`
- `pnpm run lint`
- `pnpm run package`
- `pnpm exec vsce package --no-dependencies --out /tmp/oil-code-secure-publish-test.vsix`
- `pnpm test`

## Notes
- Open VSX publishing still uses `OPEN_VSX_TOKEN`.
- The GitHub repository will need `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` secrets for the federated Azure identity before the first non-dry-run release.
