### PR TITLE
chore(deps): update fast-uri security override

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,7 +263,7 @@
       "brace-expansion@>=1.0.0 <1.1.17": "1.1.18",
       "brace-expansion@>=2.0.0 <2.1.3": "2.1.4",
       "brace-expansion@>=5.0.0 <5.0.7": "5.0.8",
-      "fast-uri@>=3.0.0 <=3.1.3": "3.1.4",
+      "fast-uri@>=3.0.0 <3.1.5": "3.1.5",
       "js-yaml@>=4.0.0 <4.3.0": "4.3.0",
       "markdown-it>linkify-it": "5.0.2",
       "npm-run-all>shell-quote": "1.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   brace-expansion@>=1.0.0 <1.1.17: 1.1.18
   brace-expansion@>=2.0.0 <2.1.3: 2.1.4
   brace-expansion@>=5.0.0 <5.0.7: 5.0.8
-  fast-uri@>=3.0.0 <=3.1.3: 3.1.4
+  fast-uri@>=3.0.0 <3.1.5: 3.1.5
   js-yaml@>=4.0.0 <4.3.0: 4.3.0
   markdown-it>linkify-it: 5.0.2
   npm-run-all>shell-quote: 1.10.0
@@ -1516,8 +1516,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4398,7 +4398,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5142,7 +5142,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
## Summary

- update the `fast-uri` pnpm override from `3.1.4` to `3.1.5`
- expand the override selector to cover the advisory's full vulnerable range
- refresh only the corresponding `pnpm-lock.yaml` resolution

## Security context

- Dependabot alert: https://github.com/corwinm/oil.code/security/dependabot/81
- Advisory: GHSA-7p8r-x3mc-p8w7 / CVE-2026-18446 (high severity)
- Vulnerable range: `>=3.0.0 <3.1.5`
- First patched version: `3.1.5`
- Resolved path: `@vscode/vsce > @secretlint/node > @secretlint/config-loader > ajv > fast-uri`

The focused audit finding for `fast-uri` is resolved. `pnpm audit` still reports one unrelated pre-existing high-severity `brace-expansion` advisory (GHSA-rgw5-rvv9-x895), which is intentionally left out of this PR.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm why fast-uri --dev` (all resolved paths use `3.1.5`)
- `pnpm audit --json` (the `fast-uri` finding is gone; vulnerabilities reduced from 2 high to 1 unrelated high)
- `pnpm test` (26 passing)
- `pnpm run verify:release`
- `pnpm exec vsce package --no-dependencies --out /tmp/oil-code-fast-uri-81.vsix`
